### PR TITLE
enable multi-platform builds

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -31,6 +31,7 @@ jobs:
           context: "{{defaultContext}}:chamaeleon"
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/chamaeleon:latest
+          platforms: linux/arm64,linux/amd64
           
   pub_hamster:
     runs-on: ubuntu-latest    
@@ -52,3 +53,4 @@ jobs:
           context: "{{defaultContext}}:hamster"
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/hamster:latest
+          platforms: linux/arm64,linux/amd64


### PR DESCRIPTION
this should prevent the issue of the previously `linux/amd64`-only images not running on raspi (`linux/arm64`)